### PR TITLE
Allow an options.preCreate function to be run on a PhantomJS WebPage instance

### DIFF
--- a/tasks/autoshot.js
+++ b/tasks/autoshot.js
@@ -44,8 +44,12 @@ module.exports = function(grunt) {
       var path = opts.path;
       var src = opts.src;
       var dest = opts.dest;
+      var preCreate = opts.preCreate;
 
       phantom.create(function(err, ph) {
+        if (typeof preCreate === 'function') {
+            preCreate(ph);
+        }
         ph.createPage(function(err, page) {
           if (viewport) {
             var sets = viewport.match(/(\d+)x(\d+)/);
@@ -97,7 +101,8 @@ module.exports = function(grunt) {
             //url: file.src
             viewport: view,
             src: file.src,
-            dest: file.dest
+            dest: file.dest,
+            preCreate: options.preCreate
           }, function() {
             cb();
           });
@@ -126,7 +131,8 @@ module.exports = function(grunt) {
               type: 'local',
               viewport: view, 
               src: 'http://localhost:' + options.local.port + '/' + file.src,
-              dest: file.dest
+              dest: file.dest,
+              preCreate: options.preCreate
             }, function() {
               cb();
             });


### PR DESCRIPTION
This pull request allows us to access the [WebPage](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage) before generating the screenshot. This is helpful to me because I want to add cookies and access pages that require authentication. With this pull request I can use something like the following Gruntfile.js:

``` javascript
module.exports = function(grunt) {
    grunt.initConfig({
        autoshot: {
            public: {
                options: {
                    path: '/tmp',
                    remote: {
                        files: [
                            { src: 'http://localhost:8000/', dest: 'login.png' }
                        ]
                    },
                    local: null,
                    preCreate: null,
                    viewport: [
                        '320x480',
                        '600x1024',
                        '1024x768',
                        '1280x800',
                        '1440x900'
                    ]
                }
            },
            authenticated: {
                options: {
                    path: '/tmp',
                    remote: {
                        files: [
                            { src: 'http://localhost:8000/', dest: 'dashboard.png' }
                        ]
                    },
                    local: null,
                    preCreate: function(ph) {
                        ph.addCookie({
                          'name': 'sessionid',
                          'value': 'v48054jkxxjwtb7cmzwa6iaqimjzs0ax',
                          'domain': 'localhost',
                          'path': '/',
                          'httponly': true,
                          'secure': false,
                          'expires':  (new Date()).getTime() + (1000 * 60 * 60)
                        });
                    },
                    viewport: [
                        '320x480',
                        '600x1024',
                        '1024x768',
                        '1280x800',
                        '1440x900'
                    ]
                }
            }
        }
    });
    grunt.loadNpmTasks('grunt-autoshot');
};
```
- <code>grunt autoshot:public</code> - takes a screenshot of localhost:8000 as normal
- <code>grunt autoshot:authenticated</code> - adds a cookie which gives us access to the dashboard at localhost:8000 which requires authentication

What you do in preCreate (how you get the cookie value, for example) is up to you.
