### PR TITLE
Add option to crop images to the size of viewport

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
             '1024x768',
             '640x960'
           ],
-          crop: true
+          crop: false
         },
       },
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,7 +51,8 @@ module.exports = function(grunt) {
             '1920x1080',
             '1024x768',
             '640x960'
-          ]
+          ],
+          crop: true
         },
       },
     },

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ grunt.initConfig({
             { src: LOCAL_FILENAME, dest: FILENAME(INCLUDE FILE TYPE), delay: DELAY_MILLISECOND }
           ]
         },
-        viewport: [] 
+        viewport: [],
+        crop: false 
       },
     },
   },
@@ -103,6 +104,11 @@ Autoshot could create the screenshot base on given viewport, it's helpful if you
 ex: ['1024x768', '1920x1080']
 ```
 You could add any resolution you want, just follow the same format.
+
+#### options.crop
+Type: Boolean. Default: false
+
+Crop screenshots to the size(s) provided in options.viewport. This is useful if you need all your screenshots to have the same width/height.
 
 ### emitter.setMaxListeners
 

--- a/tasks/autoshot.js
+++ b/tasks/autoshot.js
@@ -31,7 +31,8 @@ module.exports = function(grunt) {
           {src: "index.html", dest: "screenshot.jpg"}
         ]
       },
-      viewport: ['1920x1080']
+      viewport: ['1920x1080'],
+      crop: true
     });
 
     // Core screenshot function using phamtonJS

--- a/tasks/autoshot.js
+++ b/tasks/autoshot.js
@@ -43,6 +43,7 @@ module.exports = function(grunt) {
       var src = opts.src;
       var dest = opts.dest;
       var delay = opts.delay;
+      var crop = opts.crop;
 
       phantom.create(function(err, ph) {
         return ph.createPage(function(err, page) {
@@ -54,6 +55,15 @@ module.exports = function(grunt) {
                 height: sets[2]
               });
             }
+
+          }
+          if (crop) {
+            console.log(page);
+            // page.set('cliprect', {
+            //   top: 0,
+            //   left: 0,
+            //   width:
+            // });
           }
           page.set('zoomFactor', 1);
           return page.open(src, function(err, status) {
@@ -104,7 +114,8 @@ module.exports = function(grunt) {
             viewport: view,
             src: file.src,
             dest: file.dest,
-            delay: file.delay
+            delay: file.delay,
+            crop: options.crop
           }, function() {
             cb();
           });
@@ -131,7 +142,8 @@ module.exports = function(grunt) {
               viewport: view, 
               src: 'http://localhost:' + options.local.port + '/' + file.src,
               dest: file.dest,
-              delay: file.delay
+              delay: file.delay,
+              crop: options.crop
             }, function() {
               cb();
             });

--- a/tasks/autoshot.js
+++ b/tasks/autoshot.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
         ]
       },
       viewport: ['1920x1080'],
-      crop: true
+      crop: false
     });
 
     // Core screenshot function using phamtonJS
@@ -56,15 +56,18 @@ module.exports = function(grunt) {
               });
             }
 
+            // crop to viewport size
+            if (crop) {
+              page.set('clipRect', {
+                top: 0,
+                left: 0,
+                width: sets[1],
+                height: sets[2]
+              });
+            }
+
           }
-          if (crop) {
-            console.log(page);
-            // page.set('cliprect', {
-            //   top: 0,
-            //   left: 0,
-            //   width:
-            // });
-          }
+
           page.set('zoomFactor', 1);
           return page.open(src, function(err, status) {
             var target = type + '-' + viewport + '-' + dest;


### PR DESCRIPTION
The crop option enables Autoshot to crop screenshots to the size(s) provided in the viewport option. This is useful if you need all your screenshots to have the same width/height. This partially addresses #9.
